### PR TITLE
fix: update event name from 'ready' to 'clientReady'

### DIFF
--- a/01-getting-started/src/app.update.ts
+++ b/01-getting-started/src/app.update.ts
@@ -5,8 +5,8 @@ import { Context, ContextOf, On, Once } from 'necord';
 export class AppUpdate {
 	private readonly logger = new Logger(AppUpdate.name);
 
-	@Once('ready')
-	public async onReady(@Context() [client]: ContextOf<'ready'>) {
+	@Once('clientReady')
+	public async onReady(@Context() [client]: ContextOf<'clientReady'>) {
 		this.logger.log(`Bot logged in as ${client.user.username}`);
 	}
 

--- a/08-lavalink/src/app.service.ts
+++ b/08-lavalink/src/app.service.ts
@@ -5,8 +5,8 @@ import { ContextOf, Ctx, Once } from 'necord';
 @Injectable()
 export class AppService {
 	private readonly logger = new Logger(AppService.name);
-	@Once('ready')
-	public onReady(@Ctx() [client]: ContextOf<'ready'>) {
+	@Once('clientReady')
+	public onReady(@Ctx() [client]: ContextOf<'clientReady'>) {
 		this.logger.log(`Bot is ready! Logged in as ${client.user.tag}`);
 	}
 

--- a/09-dynamic-guilds/src/app.service.ts
+++ b/09-dynamic-guilds/src/app.service.ts
@@ -5,8 +5,8 @@ import { ContextOf, Ctx, Once } from 'necord';
 export class AppService {
 	private readonly logger = new Logger(AppService.name);
 
-	@Once('ready')
-	public onReady(@Ctx() [client]: ContextOf<'ready'>) {
+	@Once('clientReady')
+	public onReady(@Ctx() [client]: ContextOf<'clientReady'>) {
 		this.logger.log(`Bot is ready! Logged in as ${client.user.tag}`);
 	}
 }

--- a/09-dynamic-guilds/src/command.service.ts
+++ b/09-dynamic-guilds/src/command.service.ts
@@ -14,7 +14,7 @@ export class CommandService implements OnApplicationBootstrap {
 	) {}
 
 	async onApplicationBootstrap() {
-		this.client.once('ready', async () => {
+		this.client.once('clientReady', async () => {
 			await this.updateCommandsMeta();
 			await this.commandService.registerAllCommands()
 		});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Update the examples, following the deprecation of "ready"
**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
